### PR TITLE
Adding `--host` to hotel options.

### DIFF
--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -18,6 +18,10 @@ const addOptions = {
     describe: 'Set PORT environment variable',
     number: true
   },
+  host: {
+    alias: 'H',
+    describe: 'Set HOST environment variable'
+  },
   out: {
     alias: 'o',
     describe: 'Output file'

--- a/lib/cli/servers.js
+++ b/lib/cli/servers.js
@@ -96,6 +96,11 @@ function add(param, opts = {}) {
     if (opts.port) {
       conf.env.PORT = opts.port;
     }
+
+    // Copy host option
+    if (opts.H) {
+      conf.env.HOST = opts.H;
+    }
   }
 
   const data = JSON.stringify(conf, null, 2);

--- a/lib/cli/servers.js
+++ b/lib/cli/servers.js
@@ -98,8 +98,8 @@ function add(param, opts = {}) {
     }
 
     // Copy host option
-    if (opts.H) {
-      conf.env.HOST = opts.H;
+    if (opts.host) {
+      conf.env.HOST = opts.host;
     }
   }
 

--- a/lib/daemon/group.js
+++ b/lib/daemon/group.js
@@ -292,7 +292,7 @@ class Group extends EventEmitter {
     // http://app.localhost:5000 should proxy to http://localhost:5000
 
     if (port) {
-      const target = `http://127.0.0.1:${port}`;
+      const target = item.env.HOST ? `http://${item.env.HOST}:${port}` : `http://127.0.0.1:${port}`;
 
       log(`Proxy - http://${req.headers.host} → ${target}`);
       return this.proxyWeb(req, res, target);
@@ -309,8 +309,7 @@ class Group extends EventEmitter {
 
     if (item.start) {
       // Set target
-      item.target = `http://localhost:${item.env.PORT}`;
-
+      item.target = item.env.HOST ? `http://${item.env.HOST}:${item.env.PORT}` : `http://127.0.0.1:${item.env.PORT}`;
       // If server stops, no need to wait for timeout
       item.once('stop', send);
 
@@ -349,13 +348,13 @@ class Group extends EventEmitter {
 
     if (item.start) {
       // Set target
-      item.target = `http://${req.hostname}:${item.env.PORT}`;
+      item.target = item.env.HOST ? `http://${item.env.HOST}:${item.env.PORT}` : `http://${req.hostname}:${item.env.PORT}`;
 
       // If server stops, no need to wait for timeout
       item.once('stop', send);
 
       // When PORT is open, redirect
-      serverReady(item.env.PORT, send);
+      serverReady(item.env.PORT, item.env.HOST, send);
     } else {
       // Send immediatly if item is not a server started by a command
       send();
@@ -391,7 +390,7 @@ class Group extends EventEmitter {
         if (port && port !== '80') {
           target = `ws://127.0.0.1:${port}`;
         } else if (item.start) {
-          target = `ws://127.0.0.1:${item.env.PORT}`;
+          target = item.env.HOST ? `ws://${item.env.HOST}:${item.env.PORT}` : `ws://127.0.0.1:${item.env.PORT}`;
         } else {
           var _url$parse = url.parse(item.target);
 
@@ -433,13 +432,17 @@ class Group extends EventEmitter {
 
       if (item) {
         if (port && port !== '80') {
-          log(`Connect - ${host} → ${port}`);
-          tcpProxy.proxy(socket, port);
-        } else if (item.start) {
-          const PORT = item.env.PORT;
+          const HOST = item.env.HOST;
 
-          log(`Connect - ${host} → ${PORT}`);
-          tcpProxy.proxy(socket, PORT);
+          log(`Connect - proxy socket to ${port}`);
+          tcpProxy.proxy(socket, port, HOST || '127.0.0.1');
+        } else if (item.start) {
+          var _item$env = item.env;
+          const PORT = _item$env.PORT,
+                HOST = _item$env.HOST;
+
+          log(`Connect - proxy socket to ${PORT}`);
+          tcpProxy.proxy(socket, PORT, HOST || '127.0.0.1');
         } else {
           var _url$parse2 = url.parse(item.target);
 

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -14,7 +14,7 @@ const addOptions = {
     describe: 'Set PORT environment variable',
     number: true
   },
-  'host', {
+  host: {
     alias: 'H',
     describe: 'Set HOST environment variable'
   },

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -14,6 +14,10 @@ const addOptions = {
     describe: 'Set PORT environment variable',
     number: true
   },
+  'host', {
+    alias: 'H',
+    describe: 'Set HOST environment variable'
+  },
   out: {
     alias: 'o',
     describe: 'Output file'

--- a/src/cli/servers.js
+++ b/src/cli/servers.js
@@ -98,8 +98,8 @@ function add(param, opts = {}) {
     }
 
     // Copy host option
-    if (opts.H) {
-      conf.env.HOST = opts.H
+    if (opts.host) {
+      conf.env.HOST = opts.host
     }
   }
 

--- a/src/cli/servers.js
+++ b/src/cli/servers.js
@@ -96,6 +96,11 @@ function add(param, opts = {}) {
     if (opts.port) {
       conf.env.PORT = opts.port
     }
+
+    // Copy host option
+    if (opts.H) {
+      conf.env.HOST = opts.H
+    }
   }
 
   const data = JSON.stringify(conf, null, 2)

--- a/src/daemon/group.js
+++ b/src/daemon/group.js
@@ -314,8 +314,9 @@ class Group extends EventEmitter {
 
     if (item.start) {
       // Set target
-      item.target = `http://localhost:${item.env.PORT}`
-
+      item.target = item.env.HOST
+        ? `http://${item.env.HOST}:${item.env.PORT}`
+        : `http://127.0.0.1:${item.env.PORT}`
       // If server stops, no need to wait for timeout
       item.once('stop', send)
 
@@ -353,13 +354,15 @@ class Group extends EventEmitter {
 
     if (item.start) {
       // Set target
-      item.target = `http://${req.hostname}:${item.env.PORT}`
+      item.target = item.env.HOST
+        ? `http://${item.env.HOST}:${item.env.PORT}`
+        : `http://${req.hostname}:${item.env.PORT}`
 
       // If server stops, no need to wait for timeout
       item.once('stop', send)
 
       // When PORT is open, redirect
-      serverReady(item.env.PORT, send)
+      serverReady(item.env.PORT, item.env.HOST, send)
     } else {
       // Send immediatly if item is not a server started by a command
       send()
@@ -385,7 +388,9 @@ class Group extends EventEmitter {
         if (port && port !== '80') {
           target = `ws://127.0.0.1:${port}`
         } else if (item.start) {
-          target = `ws://127.0.0.1:${item.env.PORT}`
+          target = item.env.HOST
+            ? `ws://${item.env.HOST}:${item.env.PORT}`
+            : `ws://127.0.0.1:${item.env.PORT}`
         } else {
           const { hostname } = url.parse(item.target)
           target = `ws://${hostname}`
@@ -418,12 +423,13 @@ class Group extends EventEmitter {
 
       if (item) {
         if (port && port !== '80') {
-          log(`Connect - ${host} → ${port}`)
-          tcpProxy.proxy(socket, port)
+          const { HOST } = item.env
+          util.log(`Connect - proxy socket to ${port}`)
+          tcpProxy.proxy(socket, port, HOST || '127.0.0.1')
         } else if (item.start) {
-          const { PORT } = item.env
-          log(`Connect - ${host} → ${PORT}`)
-          tcpProxy.proxy(socket, PORT)
+          const { PORT, HOST } = item.env
+          util.log(`Connect - proxy socket to ${PORT}`)
+          tcpProxy.proxy(socket, PORT, HOST || '127.0.0.1')
         } else {
           const { hostname, port } = url.parse(item.target)
           const targetPort = port || 80

--- a/src/daemon/group.js
+++ b/src/daemon/group.js
@@ -298,7 +298,9 @@ class Group extends EventEmitter {
     // Handle case where port is set
     // http://app.localhost:5000 should proxy to http://localhost:5000
     if (port) {
-      const target = `http://127.0.0.1:${port}`
+      const target = item.env.HOST
+        ? `http://${item.env.HOST}:${port}`
+        : `http://127.0.0.1:${port}`
 
       log(`Proxy - http://${req.headers.host} → ${target}`)
       return this.proxyWeb(req, res, target)
@@ -424,11 +426,11 @@ class Group extends EventEmitter {
       if (item) {
         if (port && port !== '80') {
           const { HOST } = item.env
-          util.log(`Connect - proxy socket to ${port}`)
+          log(`Connect - proxy socket to ${port}`)
           tcpProxy.proxy(socket, port, HOST || '127.0.0.1')
         } else if (item.start) {
           const { PORT, HOST } = item.env
-          util.log(`Connect - proxy socket to ${PORT}`)
+          log(`Connect - proxy socket to ${PORT}`)
           tcpProxy.proxy(socket, PORT, HOST || '127.0.0.1')
         } else {
           const { hostname, port } = url.parse(item.target)

--- a/test/cli/servers.js
+++ b/test/cli/servers.js
@@ -47,6 +47,7 @@ test('add should support options', t => {
   const cmd = 'node index.js'
   const name = 'project'
   const port = 3000
+  const host = '127.0.0.1'
   const out = '/some/path/out.log'
   const env = ['FOO', 'BAR']
 
@@ -59,6 +60,7 @@ test('add should support options', t => {
     name,
     '-p',
     port,
+    '-H', host,
     '-o',
     out,
     '-e',
@@ -79,7 +81,8 @@ test('add should support options', t => {
       PATH: process.env.PATH,
       FOO: process.env.FOO,
       BAR: process.env.BAR,
-      PORT: port
+      PORT: port,
+      HOST: host
     },
     xfwd: true,
     changeOrigin: true,

--- a/test/daemon/app.js
+++ b/test/daemon/app.js
@@ -38,6 +38,15 @@ test.before(() => {
     xfwd: true
   })
 
+  // Bind server to 127.0.0.2
+  servers.add('node index.js', {
+    n: 'node2',
+    p: 61234,
+    H: '127.0.0.2',
+    d: path.join(__dirname, '../fixtures/app'),
+    o: '/tmp/logs/app.log'
+  })
+
   // Add server with subdomain
   servers.add('node index.js', {
     name: 'subdomain.node',
@@ -271,6 +280,26 @@ test.cb('GET http://localhost:2000/proxy should redirect to target', t => {
 })
 
 // TODO: Add tests for forward-by-proxy cases
+
+test.cb('GET http://localhost:2000/node2 should use the custom HOST to redirect', t => {
+  // temporary disable this test on AppVeyor
+  // Randomly fails
+  if (process.env.APPVEYOR) return t.end()
+  request(app)
+    .get('/node2')
+    .expect('location', /http:\/\/127.0.0.2:61234/)
+    .expect(302, t.end)
+})
+
+test.cb('GET http://127.0.0.1:2000/node2 should use the custom HOST to redirect', t => {
+  // temporary disable this test on AppVeyor
+  // Randomly fails
+  if (process.env.APPVEYOR) return t.end()
+  request(app)
+    .get('/node2')
+    .expect('location', /http:\/\/127.0.0.2:61234/)
+    .expect(302, t.end)
+})
 
 //
 // Test daemon/app.js

--- a/test/daemon/app.js
+++ b/test/daemon/app.js
@@ -289,7 +289,7 @@ test.cb('GET http://localhost:2000/node2 should use the custom HOST to redirect'
     .get('/node2')
     .set('Host', 'localhost')
     // TODO: Fix this test for redirect
-    // .expect('location', /http:\/\/127.0.0.2:61234/)
+    .expect('location', /http:\/\/127.0.0.2:61234/)
     .expect(307, t.end)
 })
 

--- a/test/daemon/app.js
+++ b/test/daemon/app.js
@@ -40,11 +40,11 @@ test.before(() => {
 
   // Bind server to 127.0.0.2
   servers.add('node index.js', {
-    n: 'node2',
-    p: 61234,
-    H: '127.0.0.2',
-    d: path.join(__dirname, '../fixtures/app'),
-    o: '/tmp/logs/app.log'
+    name: 'node2',
+    port: 61234,
+    host: '127.0.0.2',
+    dir: path.join(__dirname, '../fixtures/app'),
+    out: '/tmp/logs/app.log'
   })
 
   // Add server with subdomain
@@ -213,7 +213,7 @@ test.cb('GET /_/servers', t => {
     .get('/_/servers')
     .expect(200, (err, res) => {
       if (err) return t.end(err)
-      t.is(Object.keys(res.body).length, 10, 'got wrong number of servers')
+      t.is(Object.keys(res.body).length, 11, 'got wrong number of servers')
       t.end()
     })
 })
@@ -287,18 +287,10 @@ test.cb('GET http://localhost:2000/node2 should use the custom HOST to redirect'
   if (process.env.APPVEYOR) return t.end()
   request(app)
     .get('/node2')
-    .expect('location', /http:\/\/127.0.0.2:61234/)
-    .expect(302, t.end)
-})
-
-test.cb('GET http://127.0.0.1:2000/node2 should use the custom HOST to redirect', t => {
-  // temporary disable this test on AppVeyor
-  // Randomly fails
-  if (process.env.APPVEYOR) return t.end()
-  request(app)
-    .get('/node2')
-    .expect('location', /http:\/\/127.0.0.2:61234/)
-    .expect(302, t.end)
+    .set('Host', 'localhost')
+    // TODO: Fix this test for redirect
+    // .expect('location', /http:\/\/127.0.0.2:61234/)
+    .expect(307, t.end)
 })
 
 //

--- a/test/daemon/app.js
+++ b/test/daemon/app.js
@@ -288,7 +288,6 @@ test.cb('GET http://localhost:2000/node2 should use the custom HOST to redirect'
   request(app)
     .get('/node2')
     .set('Host', 'localhost')
-    // TODO: Fix this test for redirect
     .expect('location', /http:\/\/127.0.0.2:61234/)
     .expect(307, t.end)
 })


### PR DESCRIPTION
We added `--host` options to allow hotel to proxy /redirect request to a different host than the one specified.

## Test plan:

This should run the test in:
```
yarn test
```

This is also used in our private repo as reviewers would be aware.
